### PR TITLE
Revert "Hold AOUS for german umlauts"

### DIFF
--- a/config/corne.keymap
+++ b/config/corne.keymap
@@ -19,57 +19,19 @@
             };
         };
 
-        behaviors {
-            ae: a_umlaut {
-                compatible = "zmk,behavior-hold-tap";
-                #binding-cells = <2>;
-                tapping-term-ms = <200>;
-                quick-tap-ms = <150>;
-                flavor = "tap-preferred";
-                bindings = <&de_ae>, <&kp>;
-            };
-            
-            oe: o_umlaut {
-                compatible = "zmk,behavior-hold-tap";
-                #binding-cells = <2>;
-                tapping-term-ms = <200>;
-                quick-tap-ms = <150>;
-                flavor = "tap-preferred";
-                bindings = <&de_oe>, <&kp>;
-            };
-            
-            ue: u_umlaut {
-                compatible = "zmk,behavior-hold-tap";
-                #binding-cells = <2>;
-                tapping-term-ms = <200>;
-                quick-tap-ms = <150>;
-                flavor = "tap-preferred";
-                bindings = <&de_ue>, <&kp>;
-            };
-            
-            sz: sharp_s {
-                compatible = "zmk,behavior-hold-tap";
-                #binding-cells = <2>;
-                tapping-term-ms = <200>;
-                quick-tap-ms = <150>;
-                flavor = "tap-preferred";
-                bindings = <&de_eszett>, <&kp>;
-            };
-        };
-
         keymap {
                 compatible = "zmk,keymap";
 
                 default_layer {
 // -----------------------------------------------------------------------------------------
-// |  TAB |  Q  |  W  |  E   |  R  |  T  |   |  Y  | U/Ü  |  I  | O/Ö |  P  | BKSP |
-// |  ESC | A/Ä | S/ß |  D   |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |  '   |
+// |  TAB |  Q  |  W  |  E   |  R  |  T  |   |  Y  |  U   |  I  |  O  |  P  | BKSP |
+// |  ESC |  A  |  S  |  D   |  F  |  G  |   |  H  |  J   |  K  |  L  |  ;  |  '   |
 // | SHFT |  Z  |  X  |  C   |  V  |  B  |   |  N  |  M   |  ,  |  .  |  /  | GUI  |
-//                    | CTRL | LWR | SPC |   | ENT | RSE  | ALT |ẞ
+//                    | CTRL | LWR | SPC |   | ENT | RSE  | ALT |
                         display-name = "Base";
                         bindings = <
-   &kp TAB   &kp Q &kp W &kp E &kp R &kp T   &kp Y &ue 0 U  &kp I     &oe 0 O   &kp P    &kp BSPC
-   &kp ESC   &ae 0 A &sz 0 S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
+   &kp TAB   &kp Q &kp W &kp E &kp R &kp T   &kp Y &kp U  &kp I     &kp O   &kp P    &kp BSPC
+   &kp ESC   &kp A &kp S &kp D &kp F &kp G   &kp H &kp J  &kp K     &kp L   &kp SEMI &kp SQT
    &kp LSHFT &kp Z &kp X &kp C &kp V &kp B   &kp N &kp M  &kp COMMA &kp DOT &kp FSLH &kp LGUI
                   &kp LCTRL &mo 1 &kp SPACE   &kp RET &mo 2 &kp LALT
                         >;


### PR DESCRIPTION
Reverts Kahitar/corne-wireless-zmk-config-typeractive#2

I need to revert this because I cannot play games like this, where it's e.g. required to hold w,a,s,d for moving.